### PR TITLE
Update VS Code xDebug snippet

### DIFF
--- a/docs/users/snippets/launch.json
+++ b/docs/users/snippets/launch.json
@@ -8,7 +8,7 @@
             "hostname": "0.0.0.0",
             "port": 9003,
             "pathMappings": {
-                "/var/www/html": "${workspaceRoot}"
+                "/var/www/html": "${workspaceFolder}"
             }
         }
     ]


### PR DESCRIPTION
## The Problem/Issue/Bug:

VS Code has deprecated the workspace variable `${workspaceRoot}` in favor of `${workspaceFolder}`.

[Source](https://code.visualstudio.com/docs/editor/variables-reference#_why-isnt-workspaceroot-documented)